### PR TITLE
Add JSON Schema evaluation against a reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- Add JSON Schema evaluation against a reference. ([@skryukov])
+
 ### Fixed
 
 - Fix compatibility issues for Ruby < 3.1 and JRuby. ([@skryukov])

--- a/README.md
+++ b/README.md
@@ -78,6 +78,43 @@ result.output(:basic)
 #        "The instance value \"Human\" must be equal to one of the elements in the defined enumeration: [\"Nord\", \"Khajiit\", \"Argonian\", \"Breton\", \"Redguard\", \"Dunmer\", \"Altmer\", \"Bosmer\", \"Orc\", \"Imperial\"]"}]}
 ```
 
+### Evaluating against a reference
+
+```ruby
+require "json_skooma"
+
+# Create a registry to store schemas, vocabularies, dialects, etc.
+JSONSkooma.create_registry("2020-12", assert_formats: true)
+
+# Load a schema
+schema_hash = {
+  "$schema" => "https://json-schema.org/draft/2020-12/schema",
+  "$defs" => {
+    "Foo": {
+      "type" => "object",
+      "properties" => { 
+        "foo" => {"enum" => ["baz"]}
+      },
+    }
+  }
+}
+
+schema = JSONSkooma::JSONSchema.new(schema_hash)
+
+result = schema.evaluate({foo: "bar"}, ref: "#/$defs/Foo")
+
+result.valid? # => false
+
+result.output(:basic)
+# {"valid"=>false,
+#  "errors"=>
+#   [{"instanceLocation"=>"", "keywordLocation"=>"/properties", "absoluteKeywordLocation"=>"urn:uuid:cb8fb0a0-ce16-416f-b5ba-2a6531992be9#/$defs/Foo/properties", "error"=>"Properties [\"foo\"] are invalid"},
+#    {"instanceLocation"=>"/foo",
+#     "keywordLocation"=>"/properties/foo/enum",
+#     "absoluteKeywordLocation"=>"urn:uuid:cb8fb0a0-ce16-416f-b5ba-2a6531992be9#/$defs/Foo/properties/foo/enum",
+#     "error"=>"The instance value \"bar\" must be equal to one of the elements in the defined enumeration: [\"baz\"]"}]}
+```
+
 ## Alternatives
 
 - [json_schemer](https://github.com/davishmcclurg/json_schemer) – Draft 4, 6, 7, 2019-09 and 2020-12 compliant

--- a/lib/json_skooma/json_schema.rb
+++ b/lib/json_skooma/json_schema.rb
@@ -25,7 +25,9 @@ module JSONSkooma
       resolve_references if parent.nil?
     end
 
-    def evaluate(instance, result = nil)
+    def evaluate(instance, result = nil, ref: nil)
+      return resolve_ref(ref).evaluate(instance, result) if ref
+
       instance = JSONSkooma::JSONNode.new(instance) unless instance.is_a?(JSONNode)
 
       result ||= Result.new(self, instance)
@@ -49,6 +51,18 @@ module JSONSkooma
       end
 
       result
+    end
+
+    def resolve_uri(uri)
+      uri = URI.parse(uri)
+      return uri if uri.absolute?
+      return base_uri + uri if base_uri
+
+      raise Error, "No base URI against which to resolve uri `#{uri}`"
+    end
+
+    def resolve_ref(uri)
+      registry.schema(resolve_uri(uri), metaschema_uri: metaschema_uri, cache_id: cache_id)
     end
 
     def validate

--- a/lib/json_skooma/keywords/core/ref.rb
+++ b/lib/json_skooma/keywords/core/ref.rb
@@ -7,27 +7,12 @@ module JSONSkooma
         self.key = "$ref"
 
         def resolve
-          uri = resolve_uri
-          @ref_schema = parent_schema.registry.schema(
-            uri,
-            metaschema_uri: parent_schema.metaschema_uri,
-            cache_id: parent_schema.cache_id
-          )
+          @ref_schema = parent_schema.resolve_ref(json)
         end
 
         def evaluate(instance, result)
           @ref_schema.evaluate(instance, result)
           result.ref_schema = @ref_schema
-        end
-
-        private
-
-        def resolve_uri
-          uri = URI.parse(json)
-          return uri if uri.absolute?
-          return parent_schema.base_uri + uri if parent_schema.base_uri
-
-          raise Error, "No base URI against which to resolve the `$ref` value `#{uri}`"
         end
       end
     end

--- a/spec/json_skooma/json_schema_spec.rb
+++ b/spec/json_skooma/json_schema_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe JSONSkooma::JSONSchema do
+  before(:all) { JSONSkooma.create_registry("2020-12", assert_formats: true) }
+
+  describe "#evaluate" do
+    subject(:evaluate) { schema.evaluate(instance, ref: ref) }
+
+    let(:schema) { JSONSkooma::JSONSchema.new(schema_data) }
+    let(:instance) { {foo: "bar"} }
+    let(:ref) { nil }
+
+    let(:schema_data) do
+      {
+        "$schema" => "https://json-schema.org/draft/2020-12/schema",
+        "type" => "object",
+        "properties" => {
+          "foo" => {
+            "type" => "string"
+          }
+        },
+        "$defs" => {
+          "FooBaz" => {
+            "type" => "object",
+            "properties" => {
+              "foo" => {
+                "type" => "string",
+                "enum" => ["baz"]
+              }
+            }
+          }
+        }
+      }
+    end
+
+    it { is_expected.to be_valid }
+
+    context "with ref option" do
+      let(:ref) { "#/$defs/FooBaz" }
+
+      it { is_expected.not_to be_valid }
+
+      context "with valid instance" do
+        let(:instance) { {foo: "baz"} }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "with invalid ref" do
+        let(:ref) { "#/$defs/BarBaz" }
+
+        it "raises an error" do
+          expect { evaluate }.to raise_error(JSONSkooma::Error, /BarBaz/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a simple interface to evaluate instances against a reference:

```ruby
require "json_skooma"

# Create a registry to store schemas, vocabularies, dialects, etc.
JSONSkooma.create_registry("2020-12", assert_formats: true)

# Load a schema
schema_hash = {
  "$schema" => "https://json-schema.org/draft/2020-12/schema",
  "$defs" => {
    "Foo": {
      "type" => "object",
      "properties" => { 
        "foo" => {"enum" => ["baz"]}
      },
    }
  }
}

schema = JSONSkooma::JSONSchema.new(schema_hash)

result = schema.evaluate({foo: "bar"}, ref: "#/$defs/Foo")

result.valid? # => false

result.output(:basic)
# {"valid"=>false,
#  "errors"=>
#   [{"instanceLocation"=>"", "keywordLocation"=>"/properties", "absoluteKeywordLocation"=>"urn:uuid:cb8fb0a0-ce16-416f-b5ba-2a6531992be9#/$defs/Foo/properties", "error"=>"Properties [\"foo\"] are invalid"},
#    {"instanceLocation"=>"/foo",
#     "keywordLocation"=>"/properties/foo/enum",
#     "absoluteKeywordLocation"=>"urn:uuid:cb8fb0a0-ce16-416f-b5ba-2a6531992be9#/$defs/Foo/properties/foo/enum",
#     "error"=>"The instance value \"bar\" must be equal to one of the elements in the defined enumeration: [\"baz\"]"}]}
```