### PR TITLE
Make `unevaluated*` keyword respect reference keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- Make `unevaluated*` keyword respect reference keywords. ([@skryukov])
+
 ## [0.2.0] - 2023-10-23
 
 ### Added

--- a/lib/json_skooma/keywords/draft_2019_09/unevaluated_items.rb
+++ b/lib/json_skooma/keywords/draft_2019_09/unevaluated_items.rb
@@ -10,6 +10,7 @@ module JSONSkooma
         self.depends_on = %w[
           items additionalItems
           if then else allOf anyOf oneOf not
+          $ref $dynamicRef
         ]
 
         LOOKUP_KEYWORDS = %w[items additionalItems unevaluatedItems].freeze

--- a/lib/json_skooma/keywords/unevaluated/unevaluated_items.rb
+++ b/lib/json_skooma/keywords/unevaluated/unevaluated_items.rb
@@ -10,6 +10,7 @@ module JSONSkooma
         self.depends_on = %w[
           prefixItems items contains
           if then else allOf anyOf oneOf not
+          $ref $dynamicRef
         ]
 
         LOOKUP_KEYWORDS = %w[items unevaluatedItems prefixItems contains].freeze

--- a/lib/json_skooma/keywords/unevaluated/unevaluated_properties.rb
+++ b/lib/json_skooma/keywords/unevaluated/unevaluated_properties.rb
@@ -10,6 +10,7 @@ module JSONSkooma
         self.depends_on = %w[
           properties patternProperties additionalProperties
           if then else dependentSchemas allOf anyOf oneOf not
+          $ref $dynamicRef
         ]
 
         LOOKUP_KEYWORDS = %w[properties patternProperties additionalProperties unevaluatedProperties].freeze


### PR DESCRIPTION
This PR adds `$ref` and `$dynamicRef` to the list of dependencies of `unevaluated*` keywords.

See https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/696