### PR TITLE
Parse remote refs

### DIFF
--- a/lib/json_skooma/keywords/core/ref.rb
+++ b/lib/json_skooma/keywords/core/ref.rb
@@ -7,29 +7,12 @@ module JSONSkooma
         self.key = "$ref"
 
         def resolve
-          add_remote_source if need_to_adding?
           @ref_schema = parent_schema.resolve_ref(json)
         end
 
         def evaluate(instance, result)
           @ref_schema.evaluate(instance, result)
           result.ref_schema = @ref_schema
-        end
-
-        def add_remote_source
-          parent_schema.registry.add_source(
-            pathname.dirname.to_s + "/",
-            JSONSkooma::Sources::Remote.new(json)
-          )
-        end
-
-        def need_to_adding?
-          json.start_with?("http") &&
-            parent_schema.registry.instance_variable_get("@uri_sources").keys.none?{ |k| json.include?(k) }
-        end
-
-        def pathname
-          Pathname.new(json)
         end
       end
     end

--- a/lib/json_skooma/keywords/core/ref.rb
+++ b/lib/json_skooma/keywords/core/ref.rb
@@ -7,12 +7,30 @@ module JSONSkooma
         self.key = "$ref"
 
         def resolve
+          add_remote_source if need_to_adding?
           @ref_schema = parent_schema.resolve_ref(json)
         end
 
         def evaluate(instance, result)
           @ref_schema.evaluate(instance, result)
           result.ref_schema = @ref_schema
+        end
+
+        def add_remote_source
+          parent_schema.registry.add_source(
+            pathname.dirname.to_s + "/",
+            JSONSkooma::Sources::Remote.new(json)
+            # JSONSkooma::Sources::Remote.new(pathname.basename)
+          )
+        end
+
+        def need_to_adding?
+          json.start_with?("http") &&
+            parent_schema.registry.instance_variable_get("@uri_sources").keys.none?{ |k| json.include?(k) }
+        end
+
+        def pathname
+          Pathname.new(json)
         end
       end
     end

--- a/lib/json_skooma/keywords/core/ref.rb
+++ b/lib/json_skooma/keywords/core/ref.rb
@@ -20,7 +20,6 @@ module JSONSkooma
           parent_schema.registry.add_source(
             pathname.dirname.to_s + "/",
             JSONSkooma::Sources::Remote.new(json)
-            # JSONSkooma::Sources::Remote.new(pathname.basename)
           )
         end
 

--- a/lib/json_skooma/sources.rb
+++ b/lib/json_skooma/sources.rb
@@ -46,7 +46,7 @@ module JSONSkooma
       def read(relative_path)
         path = suffix ? relative_path + suffix : relative_path
         url = URI.join(base, path)
-        URI.parse(url).open.read
+        url.open.read
       rescue OpenURI::HTTPError, SocketError
         raise Error, "Could not fetch #{url}"
       end


### PR DESCRIPTION
Hi @skryukov.
I want to make **Full support for external $refs for your** `skooma` gem(see this point in the Feature plans).
For this I patched `json_skooma` gem:
- resolve, parse and read external $ref's value

In the `skooma` gem I rewrited yml files for tests:
`skooma/examples/rails_app/docs/bar_openapi.yml`
```yml
openapi: 3.1.0
info:
  title: OpenAPI Sample
  version: 1.0.0

paths:
  "/":
    get:
      responses:
        "200":
          description: OK
          content:
            application/json:
              schema:
                $ref: "https://raw.githubusercontent.com/username/test_yml/main/bar_components_item.yml"

    post:
      requestBody:
        content:
          application/json:
            schema:
              $ref: "https://raw.githubusercontent.com/username/test_yml/main/bar_components_item.yml"
      responses:
        "201":
          description: OK
          content:
            application/json:
              schema:
                $ref: "https://raw.githubusercontent.com/usernamek/test_yml/main/bar_components_item.yml"
        "400":
          description: Bad Request
          content:
            application/json:
              schema:
                $ref: "bar_components_error.yml"

```
`username/test_yml/main/bar_components_item.yml`
```yml
Item:
  type: object
  unevaluatedProperties: false
  required: [foo]
  properties:
    foo:
      type: string
      enum: [bar]
```
`skooma/examples/rails_app/docs/bar_components_error.yml`
```yml
Error:
  type: object
  unevaluatedProperties: false
  required: [message]
  properties:
    message:
      type: string
```
`skooma/examples/rails_app/docs/baz_openapi.yml`
```yml
openapi: 3.1.0
info:
  title: OpenAPI Sample
  version: 1.0.0

paths:
  "/":
    get:
      responses:
        "200":
          description: OK
          content:
            application/json:
              schema:
                $ref: "https://raw.githubusercontent.com/usernamek/test_yml/main/baz_components_item.yml"

    post:
      requestBody:
        content:
          application/json:
            schema:
              $ref: "https://raw.githubusercontent.com/usernamek/test_yml/main/baz_components_item.yml"
      responses:
        "201":
          description: OK
          content:
            application/json:
              schema:
                $ref: "https://raw.githubusercontent.com/usernamek/test_yml/main/baz_components_item.yml"
        "400":
          description: Bad Request
          content:
            application/json:
              schema:
                $ref: "baz_components_error.yml"
```
`username/test_yml/main/baz_components_item.yml`
```yml
Item:
  type: object
  unevaluatedProperties: false
  required: [foo]
  properties:
    foo:
      type: string
      enum: [baz]
```
`skooma/examples/rails_app/docs/baz_components_error.yml`
```yml
Error:
  type: object
  unevaluatedProperties: false
  required: [message]
  properties:
    message:
      type: string
```
Give me feedback please.