### PR TITLE
Improve error messages for missing required keys

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+require:
+  - standard

--- a/lib/json_skooma/keywords/validation/required.rb
+++ b/lib/json_skooma/keywords/validation/required.rb
@@ -8,9 +8,20 @@ module JSONSkooma
         self.instance_types = "object"
 
         def evaluate(instance, result)
-          return if json.value.all? { |val| instance.key?(val) }
+          missing = required_keys.reject { |key| instance.key?(key) }
+          return if missing.none?
 
-          result.failure("The object is missing required properties #{json.value.join(", ")}")
+          result.failure(missing_keys_message(missing))
+        end
+
+        private
+
+        def required_keys
+          json.value
+        end
+
+        def missing_keys_message(missing)
+          "The object requires the following keys: #{required_keys.join(", ")}. Missing keys: #{missing.join(", ")}"
         end
       end
     end

--- a/spec/json_skooma/json_schema_spec.rb
+++ b/spec/json_skooma/json_schema_spec.rb
@@ -37,6 +37,29 @@ RSpec.describe JSONSkooma::JSONSchema do
 
     it { is_expected.to be_valid }
 
+    context "with required keys" do
+      before do
+        schema_data["required"] = %w[foo bar]
+        schema_data["properties"]["bar"] = {"type" => "integer"}
+      end
+
+      it { is_expected.not_to be_valid }
+
+      it "informs us which key is missing" do
+        errors = subject.output(:detailed)["errors"].map { |e| e["error"] }
+
+        expect(errors).to contain_exactly(
+          "The object requires the following keys: foo, bar. Missing keys: bar"
+        )
+      end
+
+      context "with valid instance" do
+        let(:instance) { {foo: "baz", bar: 123} }
+
+        it { is_expected.to be_valid }
+      end
+    end
+
     context "with ref option" do
       let(:ref) { "#/$defs/FooBaz" }
 


### PR DESCRIPTION
# More specific messages for required keys

Improves the error messages when required keys are missing, by listing precisely
which ones are missing.

Also:

- improves dev experience by allowing use of `debugger` by default
- improves editor experience by improving rubocop integrations

